### PR TITLE
Fix building EmulationStation with nspawn

### DIFF
--- a/ubuntu-retro-remix-image
+++ b/ubuntu-retro-remix-image
@@ -111,6 +111,12 @@ function stage_02_apt() {
 }
 
 function stage_03_build() {
+    nspawn apt -y install libboost-system-dev libboost-filesystem-dev libboost-date-time-dev libboost-locale-dev libsdl2-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev libvlccore-dev vlc-bin
+    nspawn git clone --recursive https://github.com/RetroPie/EmulationStation "${R}/tmp/emulationstation"
+    nspawn mkdir "${R}/tmp/emulationstation/build/"
+    nspawn cmake "${R}/tmp/emulationstation" -B "${R}/tmp/emulationstation/build/"
+    nspawn make -C "${R}/tmp/emulationstation/build/" -j$(nproc)
+    nspawn make -C "${R}/tmp/emulationstation/build/" install
     return
 }
 

--- a/ubuntu-retro-remix-image
+++ b/ubuntu-retro-remix-image
@@ -111,7 +111,7 @@ function stage_02_apt() {
 }
 
 function stage_03_build() {
-    nspawn apt -y install libboost-system-dev libboost-filesystem-dev libboost-date-time-dev libboost-locale-dev libsdl2-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev libvlccore-dev vlc-bin
+    nspawn apt -y install libsdl2-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev libvlccore-dev vlc-bin
     nspawn git clone --recursive https://github.com/RetroPie/EmulationStation "${R}/tmp/emulationstation"
     nspawn mkdir "${R}/tmp/emulationstation/build/"
     nspawn cmake "${R}/tmp/emulationstation" -B "${R}/tmp/emulationstation/build/"


### PR DESCRIPTION
I'm pretty positive that what we've seen yesterday was not a missing library, but CMake having issues dealing with either nspawn or the relative paths. (1)

With this stub for stage_03_build();, I was able to successfully build EmulationStation using systemd-nspawn. It builds and produces what the `file` command recognizes as aarch64 binary, but due to missing hardware, I am unable to test - I hope it works.

(1) Now thinking about it - I ran in similar issues when packaging DevilutionX and SuperTux as Snap packages, sometimes CMake is just weird.