### PR TITLE
Enforce LC_ALL=C.UTF8 inside the shell script

### DIFF
--- a/ubuntu-retro-remix-image
+++ b/ubuntu-retro-remix-image
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+LC_ALL=C.UTF8
 
 # Display help usage
 function usage () {


### PR DESCRIPTION
Enforcing LC_ALL=C.UTF8 for the commands invoked inside the shell script is necessary for stage_06_image(). Due to the different locale settings, some locales use a `,` as a delimiter instead of the `.` the script is looking for, which leads to a broken calculation of the image filesize and eventually breaks building the image.